### PR TITLE
Added help to command line options and fixed string option parsing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,17 +22,19 @@ add_executable(waywardc src/main.cc)
 target_include_directories(waywardc PUBLIC src)
 target_link_libraries(waywardc waywardc_core)
 
-enable_testing()
-set(TEST_FILES
-        test/main.cc
-        test/lexer_test.cc)
+IF(DISABLE_TESTING)
+        enable_testing()
+        set(TEST_FILES
+                test/main.cc
+                test/lexer_test.cc)
 
-add_executable(waywardc_tests ${TEST_FILES})
-target_include_directories(waywardc PRIVATE src)
-add_test(
-        NAME    test_all_in_waywardc
-        COMMAND waywardc_tests)
-find_package(GTest REQUIRED)
-target_include_directories(waywardc_tests PRIVATE src ${GTEST_INCLUDE_DIRS})
-target_link_libraries(waywardc_tests waywardc_core ${GTEST_BOTH_LIBRARIES})
+        add_executable(waywardc_tests ${TEST_FILES})
+        target_include_directories(waywardc PRIVATE src)
+        add_test(
+                NAME    test_all_in_waywardc
+                COMMAND waywardc_tests)
+        find_package(GTest REQUIRED)
+        target_include_directories(waywardc_tests PRIVATE src ${GTEST_INCLUDE_DIRS})
+        target_link_libraries(waywardc_tests waywardc_core ${GTEST_BOTH_LIBRARIES})
+ENDIF(DISABLE_TESTING)
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -21,15 +21,20 @@ bool check_string_option(std::string& out_value, const std::string& flag_prefix,
 
     const bool contains = it != std::end(args);
 
-    out_value = it->substr(flag_prefix.size());
+    if(contains) {
+        out_value = it->substr(flag_prefix.size());
+        args.erase(it);
+    }
 
-    if(contains) args.erase(it);
     return contains;
 }
 
-void print_usage() {
-    std::cout << "Usage:\n"
-            "waywardc <input_file>\n";
+void print_help() {
+    std::cout << "Wayward compiler\n\n"
+              << "Usage: waywardc <inputs> [options]\n\n"
+              << "Commands: \n"
+              << " -help        - Display this help and exit\n"
+              << " -o=<file>    - Set the output file to <file>\n";
 }
 
 bool compile(const std::vector<std::string>& input_files,
@@ -60,6 +65,12 @@ bool compile(const std::vector<std::string>& input_files,
 int main(int argc, char* argv[]) {
 
     std::vector<std::string> args(argv + 1, argv + argc);
+
+    if(check_flag("-help", args) || check_flag("--help", args)
+        	|| check_flag("-h", args)) {
+        print_help();
+        return 0;
+    }
 
     std::string output_file = "output.c";
     check_string_option(output_file, "-o=", args);


### PR DESCRIPTION
You can now get help with the -help, --help and -h command line arguments. The program prints the help and then exits no matter what other arguments are supplied.

The check_string_option function got also fixed which didn't work when the option was not supplied but checked.

Testing can now be disabled with CMake by supplying -DDISABLE_TESTING to CMake.

@Phestek PR was fully tested.